### PR TITLE
Store canonical SMILES of monomer.

### DIFF
--- a/source/org/helm/notation/MonomerStore.java
+++ b/source/org/helm/notation/MonomerStore.java
@@ -107,6 +107,11 @@ public class MonomerStore {
 		}
 
 		Monomer copyMonomer = DeepCopy.copy(monomer);
+		
+		// ensure the canonical SMILES is indexed in the monomer store
+		if (hasSmilesString) {
+			copyMonomer.setCanSMILES(smilesString);
+		}
 
 		boolean alreadyAdded = false;
 		alreadyAdded = monomerMap.containsKey(alternateId);


### PR DESCRIPTION
Avoid incorrect conflict errors when a monomer is defined with a different SMILES. Patch suggested by R Sayle.

Not clear if there are regressions as a lot of tests are failing for me before the patch.

Okay:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Xhelm>
  <HelmNotation>PEPTIDE1{A.A.A}$$$$</HelmNotation>
  <Monomers>
    <Monomer>
      <MonomerID>A</MonomerID>
      <MonomerSmiles>C[C@H](N[*])C([*])=O |$;;;_R1;;_R2;$|</MonomerSmiles>
      <MonomerMolFile>H4sIAAAAAAAAAKWSuw7CMAxF93yFJVhrOc57poipBXVgZ2RhYOD7SYIg6UOiCCtS1Hudo1snAqC73B/XGwBZNuSlZsstfEoIAAdgo1+tUiEEODMRifRlUHsfe6FRSNpz0gijS7CDMWJ5ZYpFJiVfFG3JL1Lkd0qQrmRRf2RJf9xoZG/qLP0vlJjFJQojs6qzHNdTHFrFZS6hogyb1ZRyRxptGM1lNYXz/GV9C1HVb2Paq+ZqlEz2pqqd9+r8BMdqBzAcTpmQjuQ9DVgmZ9+3QmxjiSe9Zxcz4AIAAA==</MonomerMolFile>
      <MonomerType>Backbone</MonomerType>
      <PolymerType>PEPTIDE</PolymerType>
      <NaturalAnalog>A</NaturalAnalog>
      <MonomerName>Alanine</MonomerName>
      <Attachments>
        <Attachment>
          <AttachmentID>R2-OH</AttachmentID>
          <AttachmentLabel>R2</AttachmentLabel>
          <CapGroupName>OH</CapGroupName>
          <CapGroupSmiles>O[*] |$;_R2$|</CapGroupSmiles>
        </Attachment>
        <Attachment>
          <AttachmentID>R1-H</AttachmentID>
          <AttachmentLabel>R1</AttachmentLabel>
          <CapGroupName>H</CapGroupName>
          <CapGroupSmiles>[*][H] |$_R1;$|</CapGroupSmiles>
        </Attachment>
      </Attachments>
    </Monomer>
  </Monomers>
</Xhelm>
```

Not Okay (but accepted after patch):
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Xhelm>
  <HelmNotation>PEPTIDE1{A.A.A}$$$$</HelmNotation>
  <Monomers>
    <Monomer>
      <MonomerID>A</MonomerID>
      <MonomerSmiles>*N[C@H](C(=O)*)C |$_R1;;;;;_R2;$|</MonomerSmiles>
      <MonomerMolFile>H4sIAAAAAAAAAKWSuw7CMAxF93yFJVhrOc57poipBXVgZ2RhYOD7SYIg6UOiCCtS1Hudo1snAqC73B/XGwBZNuSlZsstfEoIAAdgo1+tUiEEODMRifRlUHsfe6FRSNpz0gijS7CDMWJ5ZYpFJiVfFG3JL1Lkd0qQrmRRf2RJf9xoZG/qLP0vlJjFJQojs6qzHNdTHFrFZS6hogyb1ZRyRxptGM1lNYXz/GV9C1HVb2Paq+ZqlEz2pqqd9+r8BMdqBzAcTpmQjuQ9DVgmZ9+3QmxjiSe9Zxcz4AIAAA==</MonomerMolFile>
      <MonomerType>Backbone</MonomerType>
      <PolymerType>PEPTIDE</PolymerType>
      <NaturalAnalog>A</NaturalAnalog>
      <MonomerName>Alanine</MonomerName>
      <Attachments>
        <Attachment>
          <AttachmentID>R2-OH</AttachmentID>
          <AttachmentLabel>R2</AttachmentLabel>
          <CapGroupName>OH</CapGroupName>
          <CapGroupSmiles>O[*] |$;_R2$|</CapGroupSmiles>
        </Attachment>
        <Attachment>
          <AttachmentID>R1-H</AttachmentID>
          <AttachmentLabel>R1</AttachmentLabel>
          <CapGroupName>H</CapGroupName>
          <CapGroupSmiles>[*][H] |$_R1;$|</CapGroupSmiles>
        </Attachment>
      </Attachments>
    </Monomer>
  </Monomers>
</Xhelm>
```
