### PR TITLE
Ensure canonical SMILES is set in the MonomerFactory. Cache is update…

### DIFF
--- a/source/org/helm/notation/MonomerFactory.java
+++ b/source/org/helm/notation/MonomerFactory.java
@@ -288,6 +288,10 @@ public class MonomerFactory {
 		MonomerCache cache = null;
 		try {
 			cache = (MonomerCache) ois.readObject();
+			// ensure monomers have their canonical SMILES set to what we store
+			for (Map.Entry<String,Monomer> e : cache.getSmilesMonomerDB().entrySet()) {
+				e.getValue().setCanSMILES(e.getKey());
+			}
 		} catch (ClassNotFoundException cnfe) {
 			throw new MonomerException(
 					"Unable to deserialize monomer cache from file");
@@ -695,14 +699,13 @@ public class MonomerFactory {
 			for (Iterator it = monomerSet.iterator(); it.hasNext();) {
 				String monomerID = (String) it.next();
 				Monomer monomer = monomerMap.get(monomerID);
-				// String smiles = monomer.getCanSMILES();
-				String smiles = null;
+				String smiles = monomer.getCanSMILES();
 				try {
-					smiles = StructureParser.getUniqueExtendedSMILES(monomer
-							.getCanSMILES());
+					smiles = StructureParser.getUniqueExtendedSMILES(smiles);
 				} catch (Exception e) {
-					smiles = monomer.getCanSMILES();
+					// ignored
 				}
+				monomer.setCanSMILES(smiles);
 				map.put(smiles, monomer);
 
 			}


### PR DESCRIPTION
…d in case an old version was serialised.

Another patch following on the previous. Testing the editor I can round trip single AAs without a warning asking for an alternate ID. The unique check in the editor is done on the SMILES in the monomer entry rather than the smiles monomer map. We now ensure these are consistent.

Caches are fixed on load.